### PR TITLE
Fix pole editor

### DIFF
--- a/offgridplanner/optimization/processing.py
+++ b/offgridplanner/optimization/processing.py
@@ -280,6 +280,16 @@ class GridProcessor(OptimizationDataHandler):
         self.links_obj, _ = Links.objects.get_or_create(project=self.project)
         self.grid_results = results_json
         self.nodes_df = pd.DataFrame(self.grid_results["nodes"])
+        if "label" not in self.nodes_df:
+            self.nodes_df["label"] = ""
+            for ix, node in enumerate(
+                self.nodes_df[self.nodes_df["node_type"] == "consumer"].index
+            ):
+                self.nodes_df.loc[node, "label"] = str(ix)
+            for ix, node in enumerate(
+                self.nodes_df[self.nodes_df["node_type"] != "consumer"].index
+            ):
+                self.nodes_df.loc[node, "label"] = f"p-{ix}"
         self.links_df = pd.DataFrame(self.grid_results["links"])
 
     def grid_results_to_db(self):

--- a/offgridplanner/projects/views.py
+++ b/offgridplanner/projects/views.py
@@ -396,7 +396,7 @@ def populate_site_data(request):
         )
 
     return JsonResponse(
-        {"redirect_url": reverse("steps:project_setup", args=[proj.id])}
+        {"redirect_url": reverse("steps:simulation_results", args=[proj.id])}
     )
 
 


### PR DESCRIPTION
Handle the case that the nodes come back with no labels. Also redirect to results on edit instead of step 1 (if the user then clicks on next and passes consumer selection, the original data returned might get overwritten).