### PR TITLE
Fix language redirect crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Fix crashes in production due to translation settings ([#32](https://github.com/Aiguasol-coop/django-offgridplanner/pull/32))
 
 ## [v1.1.6-moz.3.0] – 2026-05-18
 ### Added

--- a/offgridplanner/projects/templatetags/custom_template_tags.py
+++ b/offgridplanner/projects/templatetags/custom_template_tags.py
@@ -43,7 +43,7 @@ def custom_redir_lang(url_fullpath):
     # see https://stackoverflow.com/questions/67234400/django-i18n-language-switcher-not-working-on-deploy-at-subdirectory
     ls_urls = url_fullpath.split("/")
     del ls_urls[1]
-    return "/".join(ls_urls)
+    return "/".join(ls_urls) or "/"
 
 
 @register.filter


### PR DESCRIPTION
Add fallback slash if path is root to redirect url. Was causing database connection crash in deployment due to 404Resolver errors.