### PR TITLE
Remove relational lookup from SiteExploration creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Fix server error when accessing potential map for new users ([#35](https://github.com/Aiguasol-coop/django-offgridplanner/pull/35))
 
 ## [v1.1.6-moz.3.3] – 2026-06-17
 ### Fixed

--- a/offgridplanner/projects/views.py
+++ b/offgridplanner/projects/views.py
@@ -287,7 +287,7 @@ def get_project_data(project):
 @require_http_methods(["GET", "POST"])
 def potential_map(request):
     user = request.user
-    site_exploration, _ = SiteExploration.objects.get_or_create(user__id=user.id)
+    site_exploration, _ = SiteExploration.objects.get_or_create(user=user)
     form = SiteExplorationForm(instance=site_exploration)
 
     # Save the existing MG data in the session storage to avoid sending an API request every time


### PR DESCRIPTION
Was triggering 500 errors when creating `SiteExploration` objects for new users, while succeeding on get